### PR TITLE
[#109] Adding the missing "bundle" script to the package.json file.

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,11 @@
   "browserslist": [
     "last 2 versions"
   ],
+  "scripts": {
+    "bundle": "gulp bundle",
+    "lint": "gulp lint",
+    "preview": "gulp preview"
+  },
   "devDependencies": {
     "@asciidoctor/core": "~2.2",
     "@fontsource/roboto": "~4.5",


### PR DESCRIPTION
This PR adds the missing "bundle" script to the package.json file, which resolves the failing GitHub workflow. The workflow was attempting to run npm run bundle but this script was not defined in our package.json, causing the build to fail.